### PR TITLE
Updates to support newer versions of jQuery

### DIFF
--- a/locales/en/scripts/layouts/nday-l10n.js
+++ b/locales/en/scripts/layouts/nday-l10n.js
@@ -17,7 +17,7 @@ Timegrid.NDayLayout.l10n.makeRange = function(d1, d2) {
 
 /** Format for horizontal "Mon 5/24" style labels */
 Timegrid.NDayLayout.l10n.xLabelFormat = "E M/d";
-Timegrid.NDayLayout.l10n.mini.xLabelFormat = "e";
+Timegrid.NDayLayout.l10n.mini.xLabelFormat = "E";
 
 /** Format for vertical "12am" style labels */
 Timegrid.NDayLayout.l10n.yLabelFormat = "ha";

--- a/scripts/controls.js
+++ b/scripts/controls.js
@@ -80,7 +80,7 @@ Timegrid.Controls.TabSet.prototype.render = function(container) {
         tabDiv.prepend($tab);
         this._tabs[lTitle] = $tab;
     }
-    if (!$.browser.msie) { $('.timegrid-tab').corner("30px top"); }
+    if (navigator.appVersion.indexOf("MSIE") == -1) { $('.timegrid-tab').corner("30px top"); }
 };
 
 Timegrid.Controls.TabSet.prototype.renderChanged = function() {

--- a/scripts/jquery.simile.ajax.js
+++ b/scripts/jquery.simile.ajax.js
@@ -314,8 +314,6 @@ jQuery.extend({
                     // don't have to do all the testing over again
                     // on subsequent calls.
                     return f;
-                    
-                    return o;
                 } catch (e) {
                     // silent
                 }

--- a/scripts/layouts/layout.js
+++ b/scripts/layouts/layout.js
@@ -217,7 +217,7 @@ Timegrid.Layout.prototype.render = function(container) {
     this._viewDiv.append(xLabels).append(yLabels);
     
     if (!this.mini) {
-        if ($.browser.msie) {
+        if (navigator.appVersion.indexOf("MSIE") !== -1) {
             $('.timegrid-view:visible .timegrid-rounded-shadow', 
               this._container).prettybox(4,0,0,1);
         } else {
@@ -237,7 +237,7 @@ Timegrid.Layout.prototype.renderChanged = function() {
     this.renderXLabels();
     this.renderYLabels();
     if (!this.mini) {
-        if ($.browser.msie) {
+        if (navigator.appVersion.indexOf("MSIE") !== -1) {
             $('.timegrid-view:visible .timegrid-rounded-shadow', 
               this._container).prettybox(4,0,0,1);
         } else {

--- a/scripts/util/jquery.corner.js
+++ b/scripts/util/jquery.corner.js
@@ -1,253 +1,251 @@
-	// jquery-roundcorners-canvas
-	// www.meerbox.nl
-	
-(function($){
-	
-	var _corner = function(options) {
-		
-		// no native canvas support, or its msie and excanvas.js not loaded
-		var testcanvas = document.createElement("canvas");
-		if (typeof G_vmlCanvasManager == 'undefined' && $.browser.msie) {
-			return this.each(function() {});
-		}
-		
-		// get lowest number from array
-		var asNum = function(a, b) { return a-b; };
-		var getMin = function(a) {
-			var b = a.concat();
-			return b.sort(asNum)[0];
-		};
-		
-		// get CSS value as integer
-		var getCSSint = function(el, prop) {
-			return parseInt($.css(el.jquery?el[0]:el,prop))||0;
-		};
-			
-		// draw the round corner in Canvas object
-		var drawRoundCornerCanvasShape = function(canvas,radius,r_type,bg_color,border_width,border_color) {
-			
-			// change rgba(1,2,3,0.9) to rgb(1,2,3)
-			var reg = /^rgba\((\d{1,3}),\s*(\d{1,3}),\s*(\d{1,3}),\s*(\d{1,3})\)$/;   
-			var bits = reg.exec(bg_color);
-			if (bits) {
-				channels = new Array(parseInt(bits[1]),parseInt(bits[2]),parseInt(bits[3]));
-				bg_color = 'rgb('+channels[0]+', '+channels[1]+', '+channels[2]+')';
-			} 
-		
-			var border_width = parseInt(border_width);
-			
-			var ctx = canvas.getContext('2d');
-			
-			if (radius == 1) {
-				ctx.fillStyle = bg_color;
-				ctx.fillRect(0,0,1,1);
-				return;
-			}
-	
-			if (r_type == 'tl') {
-				var steps = new Array(0,0,radius,0,radius,0,0,radius,0,0);
-			} else if (r_type == 'tr') {
-				var steps = new Array(radius,0,radius,radius,radius,0,0,0,0,0);
-			} else if (r_type == 'bl') {
-				var steps = new Array(0,radius,radius,radius,0,radius,0,0,0,radius);
-			} else if (r_type == 'br') {
-				var steps = new Array(radius,radius,radius,0,radius,0,0,radius,radius,radius);
-			}
-	          
-			ctx.fillStyle = bg_color;
-	    	ctx.beginPath();
-	     	ctx.moveTo(steps[0],steps[1]); 
-	     	ctx.lineTo(steps[2], steps[3]); 
-	    	if(r_type == 'br') ctx.bezierCurveTo(steps[4], steps[5], radius, radius, steps[6], steps[7]); 
-	    	else ctx.bezierCurveTo(steps[4], steps[5], 0, 0, steps[6], steps[7]);
-			ctx.lineTo(steps[8], steps[9]); 
-	        ctx.fill(); 
-	        
-	        // draw border
-	        if (border_width > 0 && border_width < radius) {
-		        
-		        // offset caused by border
-		        var offset = border_width/2; 
-		        
-		        if (r_type == 'tl') {
-					var steps = new Array(radius-offset,offset,radius-offset,offset,offset,radius-offset);
-					var curve_to = new Array(0,0);
-				} else if (r_type == 'tr') {
-					var steps = new Array(radius-offset,radius-offset,radius-offset,offset,offset,offset);
-					var curve_to = new Array(0,0);
-				} else if (r_type == 'bl') {
-					var steps = new Array(radius-offset,radius-offset,offset,radius-offset,offset,offset,offset,radius-offset);
-					var curve_to = new Array(0,0);
-				} else if (r_type == 'br') {
-					var steps = new Array(radius-offset,offset,radius-offset,offset,offset,radius-offset,radius-offset,radius-offset);
-					var curve_to = new Array(radius, radius);
-				}
-		        
-		        ctx.strokeStyle = border_color;
-		        ctx.lineWidth = border_width;
-	    		ctx.beginPath();
-	    		// go to corner to begin curve
-	     		ctx.moveTo(steps[0], steps[1]); 
-	     		// curve from righttop to leftbottom (for the tl canvas)
-	    		ctx.bezierCurveTo(steps[2], steps[3], curve_to[0], curve_to[1], steps[4], steps[5]); 
-				ctx.stroke();
-		        
-		    }
-		};
-		
-		var creatCanvas = function(p,radius) {
-			var elm = document.createElement('canvas');
-			elm.setAttribute("height", radius);
-    		elm.setAttribute("width", radius); 
-			elm.style.display = "block";
-			elm.style.position = "absolute";
-			elm.className = "cornercanvas";
-			elm = p.appendChild(elm); 
-			// if G_vmlCanvasManager in defined the browser (ie only) has loaded excanvas.js 
-			if (!elm.getContext && typeof G_vmlCanvasManager != 'undefined') {
-				var elm = G_vmlCanvasManager.initElement(elm);
-			}
-			return elm;
-		};
-		
-		// interpret the (string) argument
-   		var o = (options || "").toLowerCase();
-   		var radius = parseInt((o.match(/(\d+)px/)||[])[1]) || null; // corner width
-   		var bg_color = ((o.match(/(#[0-9a-f]+)/)||[])[1]);  // strip color
-   		if (radius == null) { radius = "auto"; }
-   		
-   		var edges = { T:0, B:1 };
-    	var opts = {
-        	tl:  /top|tl/.test(o),       
-        	tr:  /top|tr/.test(o),
-        	bl:  /bottom|bl/.test(o),    
-        	br:  /bottom|br/.test(o)
-    	};
-    	if ( !opts.tl && !opts.tr && !opts.bl && !opts.br) {
-        	opts = { tl:1, tr:1, bl:1, br:1 };
+/*!
+ * jQuery corner plugin: simple corner rounding
+ * Examples and documentation at: http://jquery.malsup.com/corner/
+ * version 2.13 (19-FEB-2013)
+ * Requires jQuery v1.3.2 or later
+ * Dual licensed under the MIT and GPL licenses:
+ * http://www.opensource.org/licenses/mit-license.php
+ * http://www.gnu.org/licenses/gpl.html
+ * Authors: Dave Methvin and Mike Alsup
+ */
+
+/**
+ *  corner() takes a single string argument:  $('#myDiv').corner("effect corners width")
+ *
+ *  effect:  name of the effect to apply, such as round, bevel, notch, bite, etc (default is round). 
+ *  corners: one or more of: top, bottom, tr, tl, br, or bl.  (default is all corners)
+ *  width:   width of the effect; in the case of rounded corners this is the radius. 
+ *           specify this value using the px suffix such as 10px (yes, it must be pixels).
+ */
+;(function($) { 
+
+var msie = /MSIE/.test(navigator.userAgent);
+
+var style = document.createElement('div').style,
+    moz = style['MozBorderRadius'] !== undefined,
+    webkit = style['WebkitBorderRadius'] !== undefined,
+    radius = style['borderRadius'] !== undefined || style['BorderRadius'] !== undefined,
+    mode = document.documentMode || 0,
+    noBottomFold = msie && (!mode || mode < 8),
+
+    expr = msie && (function() {
+        var div = document.createElement('div');
+        try { div.style.setExpression('width','0+0'); div.style.removeExpression('width'); }
+        catch(e) { return false; }
+        return true;
+    })();
+
+$.support = $.support || {};
+$.support.borderRadius = moz || webkit || radius; // so you can do:  if (!$.support.borderRadius) $('#myDiv').corner();
+
+function sz(el, p) { 
+    return parseInt($.css(el,p),10)||0; 
+}
+function hex2(s) {
+    s = parseInt(s,10).toString(16);
+    return ( s.length < 2 ) ? '0'+s : s;
+}
+function gpc(node) {
+    while(node) {
+        var v = $.css(node,'backgroundColor'), rgb;
+        if (v && v != 'transparent' && v != 'rgba(0, 0, 0, 0)') {
+            if (v.indexOf('rgb') >= 0) { 
+                rgb = v.match(/\d+/g); 
+                return '#'+ hex2(rgb[0]) + hex2(rgb[1]) + hex2(rgb[2]);
+            }
+            return v;
         }
-      
-		return this.each(function() {
+        if (node.nodeName.toLowerCase() == 'html')
+            break;
+        node = node.parentNode; // keep walking if transparent
+    }
+    return '#ffffff';
+}
 
-			var elm = $(this);
-			
-			// give the element 'haslayout'
-	   		if ($.browser.msie) { this.style.zoom = 1; }
-			
-			// the size of the corner is not defined...
-			var widthheight_smallest = getMin(new Array(getCSSint(this,'height'),getCSSint(this,'width')));
-			if (radius == "auto") {
-				radius = widthheight_smallest/4;
-				if (radius > 10) { radius = 10; }
-			}
+function getWidth(fx, i, width) {
+    switch(fx) {
+    case 'round':  return Math.round(width*(1-Math.cos(Math.asin(i/width))));
+    case 'cool':   return Math.round(width*(1+Math.cos(Math.asin(i/width))));
+    case 'sharp':  return width-i;
+    case 'bite':   return Math.round(width*(Math.cos(Math.asin((width-i-1)/width))));
+    case 'slide':  return Math.round(width*(Math.atan2(i,width/i)));
+    case 'jut':    return Math.round(width*(Math.atan2(width,(width-i-1))));
+    case 'curl':   return Math.round(width*(Math.atan(i)));
+    case 'tear':   return Math.round(width*(Math.cos(i)));
+    case 'wicked': return Math.round(width*(Math.tan(i)));
+    case 'long':   return Math.round(width*(Math.sqrt(i)));
+    case 'sculpt': return Math.round(width*(Math.log((width-i-1),width)));
+    case 'dogfold':
+    case 'dog':    return (i&1) ? (i+1) : width;
+    case 'dog2':   return (i&2) ? (i+1) : width;
+    case 'dog3':   return (i&3) ? (i+1) : width;
+    case 'fray':   return (i%2)*width;
+    case 'notch':  return width; 
+    case 'bevelfold':
+    case 'bevel':  return i+1;
+    case 'steep':  return i/2 + 1;
+    case 'invsteep':return (width-i)/2+1;
+    }
+}
 
-			// the size of the corner can't be to high
-			if (widthheight_smallest < radius) { 
-				radius = (widthheight_smallest/2); 
-			}
-			
-			// remove old canvas objects
-			elm.children("canvas.cornercanvas").remove();
-			
-			// some css thats required in order to position the canvas elements
-			if (elm.css('position') == 'static') { 
-				elm.css('position','relative'); 
-			// only needed for ie6 and (ie7 in Quirks mode) , CSS1Compat == Strict mode
-			} else if (elm.css('position') == 'fixed' && $.browser.msie && !(document.compatMode == 'CSS1Compat' && typeof document.body.style.maxHeight != "undefined")) { 
-				elm.css('position','absolute'); 
-			}
-			elm.css('overflow','visible'); 
-			
-			// get border width
-			var border_t = getCSSint(this, 'borderTopWidth');
-			var border_r = getCSSint(this, 'borderRightWidth');
-			var border_b = getCSSint(this, 'borderBottomWidth');
-			var border_l = getCSSint(this, 'borderLeftWidth');
-			
-			// get the lowest borderwidth of the corners in use
-			var bordersWidth = new Array();
-			if (opts.tl || opts.tr) { bordersWidth.push(border_t); }
-			if (opts.br || opts.tr) { bordersWidth.push(border_r); }
-			if (opts.br || opts.bl) { bordersWidth.push(border_b); }
-			if (opts.bl || opts.tl) { bordersWidth.push(border_l); }
-			
-			borderswidth_smallest = getMin(bordersWidth);
-			
-			// creat the canvas elements and position them
-			var p_top = 0-border_t;
-			var p_right = 0-border_r;
-			var p_bottom = 0-border_b;
-			var p_left = 0-border_l;	
+$.fn.corner = function(options) {
+    // in 1.3+ we can fix mistakes with the ready state
+    if (this.length === 0) {
+        if (!$.isReady && this.selector) {
+            var s = this.selector, c = this.context;
+            $(function() {
+                $(s,c).corner(options);
+            });
+        }
+        return this;
+    }
 
-			if (opts.tl) { var tl = $(creatCanvas(this,radius)).css({left:p_left,top:p_top}).get(0); }
-			if (opts.tr) { var tr = $(creatCanvas(this,radius)).css({right:p_right,top:p_top}).get(0); }
-			if (opts.bl) { var bl = $(creatCanvas(this,radius)).css({left:p_left,bottom:p_bottom}).get(0); }
-			if (opts.br) { var br = $(creatCanvas(this,radius)).css({right:p_right,bottom:p_bottom}).get(0); }
-			
-			// get the background color of parent element
-			
-			if (bg_color == undefined) {
-				
-				var current_p = elm.parent();
-				var bg = current_p.css('background-color');
-				while((bg == "transparent" || bg == "rgba(0, 0, 0, 0)") && current_p.get(0).tagName.toLowerCase() != "html") {
-					bg = current_p.css('background-color');
-					current_p = current_p.parent();
-				}
-			} else {
-				bg = bg_color;
-			}
+    return this.each(function(index){
+        var $this = $(this),
+            // meta values override options
+            o = [$this.attr($.fn.corner.defaults.metaAttr) || '', options || ''].join(' ').toLowerCase(),
+            keep = /keep/.test(o),                       // keep borders?
+            cc = ((o.match(/cc:(#[0-9a-f]+)/)||[])[1]),  // corner color
+            sc = ((o.match(/sc:(#[0-9a-f]+)/)||[])[1]),  // strip color
+            width = parseInt((o.match(/(\d+)px/)||[])[1],10) || 10, // corner width
+            re = /round|bevelfold|bevel|notch|bite|cool|sharp|slide|jut|curl|tear|fray|wicked|sculpt|long|dog3|dog2|dogfold|dog|invsteep|steep/,
+            fx = ((o.match(re)||['round'])[0]),
+            fold = /dogfold|bevelfold/.test(o),
+            edges = { T:0, B:1 },
+            opts = {
+                TL:  /top|tl|left/.test(o),       TR:  /top|tr|right/.test(o),
+                BL:  /bottom|bl|left/.test(o),    BR:  /bottom|br|right/.test(o)
+            },
+            // vars used in func later
+            strip, pad, cssHeight, j, bot, d, ds, bw, i, w, e, c, common, $horz;
+        
+        if ( !opts.TL && !opts.TR && !opts.BL && !opts.BR )
+            opts = { TL:1, TR:1, BL:1, BR:1 };
+            
+        // support native rounding
+        if ($.fn.corner.defaults.useNative && fx == 'round' && (radius || moz || webkit) && !cc && !sc) {
+            if (opts.TL)
+                $this.css(radius ? 'border-top-left-radius' : moz ? '-moz-border-radius-topleft' : '-webkit-border-top-left-radius', width + 'px');
+            if (opts.TR)
+                $this.css(radius ? 'border-top-right-radius' : moz ? '-moz-border-radius-topright' : '-webkit-border-top-right-radius', width + 'px');
+            if (opts.BL)
+                $this.css(radius ? 'border-bottom-left-radius' : moz ? '-moz-border-radius-bottomleft' : '-webkit-border-bottom-left-radius', width + 'px');
+            if (opts.BR)
+                $this.css(radius ? 'border-bottom-right-radius' : moz ? '-moz-border-radius-bottomright' : '-webkit-border-bottom-right-radius', width + 'px');
+            return;
+        }
+            
+        strip = document.createElement('div');
+        $(strip).css({
+            overflow: 'hidden',
+            height: '1px',
+            minHeight: '1px',
+            fontSize: '1px',
+            backgroundColor: sc || 'transparent',
+            borderStyle: 'solid'
+        });
+    
+        pad = {
+            T: parseInt($.css(this,'paddingTop'),10)||0,     R: parseInt($.css(this,'paddingRight'),10)||0,
+            B: parseInt($.css(this,'paddingBottom'),10)||0,  L: parseInt($.css(this,'paddingLeft'),10)||0
+        };
 
-			if (bg == "transparent" || bg == "rgba(0, 0, 0, 0)") { bg = "#ffffff"; }
-			
-			if (opts.tl) { drawRoundCornerCanvasShape(tl,radius,'tl',bg,borderswidth_smallest,elm.css('borderTopColor')); }
-			if (opts.tr) { drawRoundCornerCanvasShape(tr,radius,'tr',bg,borderswidth_smallest,elm.css('borderTopColor')); }
-			if (opts.bl) { drawRoundCornerCanvasShape(bl,radius,'bl',bg,borderswidth_smallest,elm.css('borderBottomColor')); }
-			if (opts.br) { drawRoundCornerCanvasShape(br,radius,'br',bg,borderswidth_smallest,elm.css('borderBottomColor')); }
-			
-			elm.addClass('roundCornersParent');
-				
-   		});  
-	};
-	
-	if ($.browser.msie && typeof G_vmlCanvasManager == 'undefined') {
-		
-		var corner_buffer = new Array();
-		var corner_buffer_args = new Array();
-		
-		$.fn.corner = function(options){
-			corner_buffer[corner_buffer.length] = this;
-    		corner_buffer_args[corner_buffer_args.length] = options;
-			return this.each(function(){});
-		};
-		
-		// load excanvas.pack.js
-		document.execCommand("BackgroundImageCache", false, true);
-		var elm = $("script[@src*=jquery.corner.]");
-		if (elm.length == 1) {
-			var jc_src = elm.attr('src');
-			var pathArray = jc_src.split('/');
-			pathArray.pop();
-			var base = pathArray.join('/') || '.';
-			var excanvasjs = base+'/excanvas.pack.js';
-			$.getScript(excanvasjs,function(){
-				 execbuffer();
-			});
-		}
-		
-		var execbuffer = function() {
-			// set back function
-			$.fn.corner = _corner;
-			// execute buffer and set back function
-			for(var i=0;i<corner_buffer.length;i++){
-				corner_buffer[i].corner(corner_buffer_args[i]);
-			}
-			corner_buffer = null;
-			corner_buffer_args = null;
-		}
-		
-	} else {
-		$.fn.corner = _corner;
-	}
-	
+        if (typeof this.style.zoom !== undefined) this.style.zoom = 1; // force 'hasLayout' in IE
+        if (!keep) this.style.border = 'none';
+        strip.style.borderColor = cc || gpc(this.parentNode);
+        cssHeight = $(this).outerHeight();
+
+        for (j in edges) {
+            bot = edges[j];
+            // only add stips if needed
+            if ((bot && (opts.BL || opts.BR)) || (!bot && (opts.TL || opts.TR))) {
+                strip.style.borderStyle = 'none '+(opts[j+'R']?'solid':'none')+' none '+(opts[j+'L']?'solid':'none');
+                d = document.createElement('div');
+                $(d).addClass('jquery-corner');
+                ds = d.style;
+
+                bot ? this.appendChild(d) : this.insertBefore(d, this.firstChild);
+
+                if (bot && cssHeight != 'auto') {
+                    if ($.css(this,'position') == 'static')
+                        this.style.position = 'relative';
+                    ds.position = 'absolute';
+                    ds.bottom = ds.left = ds.padding = ds.margin = '0';
+                    if (expr)
+                        ds.setExpression('width', 'this.parentNode.offsetWidth');
+                    else
+                        ds.width = '100%';
+                }
+                else if (!bot && msie) {
+                    if ($.css(this,'position') == 'static')
+                        this.style.position = 'relative';
+                    ds.position = 'absolute';
+                    ds.top = ds.left = ds.right = ds.padding = ds.margin = '0';
+                    
+                    // fix ie6 problem when blocked element has a border width
+                    if (expr) {
+                        bw = sz(this,'borderLeftWidth') + sz(this,'borderRightWidth');
+                        ds.setExpression('width', 'this.parentNode.offsetWidth - '+bw+'+ "px"');
+                    }
+                    else
+                        ds.width = '100%';
+                }
+                else {
+                    ds.position = 'relative';
+                    ds.margin = !bot ? '-'+pad.T+'px -'+pad.R+'px '+(pad.T-width)+'px -'+pad.L+'px' : 
+                                        (pad.B-width)+'px -'+pad.R+'px -'+pad.B+'px -'+pad.L+'px';                
+                }
+
+                for (i=0; i < width; i++) {
+                    w = Math.max(0,getWidth(fx,i, width));
+                    e = strip.cloneNode(false);
+                    e.style.borderWidth = '0 '+(opts[j+'R']?w:0)+'px 0 '+(opts[j+'L']?w:0)+'px';
+                    bot ? d.appendChild(e) : d.insertBefore(e, d.firstChild);
+                }
+                
+                if (fold && $.support.boxModel) {
+                    if (bot && noBottomFold) continue;
+                    for (c in opts) {
+                        if (!opts[c]) continue;
+                        if (bot && (c == 'TL' || c == 'TR')) continue;
+                        if (!bot && (c == 'BL' || c == 'BR')) continue;
+                        
+                        common = { position: 'absolute', border: 'none', margin: 0, padding: 0, overflow: 'hidden', backgroundColor: strip.style.borderColor };
+                        $horz = $('<div/>').css(common).css({ width: width + 'px', height: '1px' });
+                        switch(c) {
+                        case 'TL': $horz.css({ bottom: 0, left: 0 }); break;
+                        case 'TR': $horz.css({ bottom: 0, right: 0 }); break;
+                        case 'BL': $horz.css({ top: 0, left: 0 }); break;
+                        case 'BR': $horz.css({ top: 0, right: 0 }); break;
+                        }
+                        d.appendChild($horz[0]);
+                        
+                        var $vert = $('<div/>').css(common).css({ top: 0, bottom: 0, width: '1px', height: width + 'px' });
+                        switch(c) {
+                        case 'TL': $vert.css({ left: width }); break;
+                        case 'TR': $vert.css({ right: width }); break;
+                        case 'BL': $vert.css({ left: width }); break;
+                        case 'BR': $vert.css({ right: width }); break;
+                        }
+                        d.appendChild($vert[0]);
+                    }
+                }
+            }
+        }
+    });
+};
+
+$.fn.uncorner = function() { 
+    if (radius || moz || webkit)
+        this.css(radius ? 'border-radius' : moz ? '-moz-border-radius' : '-webkit-border-radius', 0);
+    $('div.jquery-corner', this).remove();
+    return this;
+};
+
+// expose options
+$.fn.corner.defaults = {
+    useNative: true, // true if plugin should attempt to use native browser support for border radius rounding
+    metaAttr:  'data-corner' // name of meta attribute to use for options
+};
+    
 })(jQuery);

--- a/scripts/util/jquery.dimensions.js
+++ b/scripts/util/jquery.dimensions.js
@@ -2,9 +2,115 @@
  * Dual licensed under the MIT (http://www.opensource.org/licenses/mit-license.php)
  * and GPL (http://www.opensource.org/licenses/gpl-license.php) licenses.
  *
- * $LastChangedDate: 2007-07-01 20:19:35 -0500 (Sun, 01 Jul 2007) $
- * $Rev: 2209 $
+ * $LastChangedDate: 2007-10-06T18:11:15.103402Z $
+ * $Rev: 4893 $
  *
- * Version: 1.0rc1
+ * Version: @VERSION
+ *
+ * Requires: jQuery 1.2+
  */
-eval(function(p,a,c,k,e,r){e=function(c){return(c<a?'':e(parseInt(c/a)))+((c=c%a)>35?String.fromCharCode(c+29):c.toString(36))};if(!''.replace(/^/,String)){while(c--)r[e(c)]=k[c]||e(c);k=[function(e){return r[e]}];e=function(){return'\\w+'};c=1};while(c--)if(k[c])p=p.replace(new RegExp('\\b'+e(c)+'\\b','g'),k[c]);return p}('(8($){p g=$.19.D,w=$.19.w;$.19.z({D:8(){4(1[0]==h)5 Z.1a||$.I&&7.10.1z||7.q.1z;4(1[0]==7)5 1t.1s(7.q.1H,7.q.13);5 g.1k(1,1h)},w:8(){4(1[0]==h)5 Z.1d||$.I&&7.10.1c||7.q.1c;4(1[0]==7)5 1t.1s(7.q.1B,7.q.11);5 w.1k(1,1h)},1a:8(){5 1[0]==h||1[0]==7?1.D():1.P(\':J\')?1[0].13-f(1,\'k\')-f(1,\'1A\'):1.D()+f(1,\'18\')+f(1,\'1y\')},1d:8(){5 1[0]==h||1[0]==7?1.w():1.P(\':J\')?1[0].11-f(1,\'j\')-f(1,\'1x\'):1.w()+f(1,\'15\')+f(1,\'1u\')},1K:8(){5 1[0]==h||1[0]==7?1.D():1.P(\':J\')?1[0].13:1.D()+f(1,\'k\')+f(1,\'1A\')+f(1,\'18\')+f(1,\'1y\')},1J:8(){5 1[0]==h||1[0]==7?1.w():1.P(\':J\')?1[0].11:1.w()+f(1,\'j\')+f(1,\'1x\')+f(1,\'15\')+f(1,\'1u\')},l:8(a){4(a!=1q)5 1.1o(8(){4(1==h||1==7)h.1m(a,$(h).n());o 1.l=a});4(1[0]==h||1[0]==7)5 Z.1G||$.I&&7.10.l||7.q.l;5 1[0].l},n:8(a){4(a!=1q)5 1.1o(8(){4(1==h||1==7)h.1m($(h).l(),a);o 1.n=a});4(1[0]==h||1[0]==7)5 Z.1F||$.I&&7.10.n||7.q.n;5 1[0].n},C:8(c,d){p a=1[0],3=a.S,6=a.R,c=$.z({Q:m,K:m,O:m,t:m},c||{}),x=a.N,y=a.M,v=a.l,u=a.n;4($.i.17||$.i.16){x+=f(a,\'j\');y+=f(a,\'k\')}4(($.i.Y||$.i.X)&&$.r(6,\'C\')!=\'W\'){x-=f(6,\'j\');y-=f(6,\'k\')}4($.i.17){B{4(3!=a&&$.r(3,\'1w\')!=\'J\'){x+=f(3,\'j\');y+=f(3,\'k\')}4(3==6)1v}H((3=3.S)&&3.s!=\'G\')}4($.i.16&&(6.s!=\'G\'&&$.r(6,\'C\')==\'W\')){B{x+=6.N;y+=6.M;x+=f(6,\'j\');y+=f(6,\'k\')}H((6=6.R)&&(6.s!=\'G\'&&$.r(6,\'C\')==\'W\'))}p b=e(a,c,x,y,v,u);4(d){$.z(d,b);5 1}o{5 b}},1I:8(b,c){p x=0,y=0,v=0,u=0,9=1[0],3=1[0],6,U,L=$.r(9,\'C\'),A=$.i.17,E=$.i.16,1p=$.i.Y,1n=$.i.X,12=m,14=m,b=$.z({Q:F,K:m,O:m,t:F,1j:m},b||{});4(b.1j)5 1.1i(b,c);4(9.s==\'G\'){x=9.N;y=9.M;4(A){x+=f(9,\'V\')+(f(9,\'j\')*2);y+=f(9,\'T\')+(f(9,\'k\')*2)}o 4(1n){x+=f(9,\'V\');y+=f(9,\'T\')}o 4(E&&1l.I){x+=f(9,\'j\');y+=f(9,\'k\')}}o{B{U=$.r(3,\'C\');x+=3.N;y+=3.M;4(A||E){x+=f(3,\'j\');y+=f(3,\'k\');4(A&&U==\'1g\')12=F;4(E&&U==\'1E\')14=F}6=3.R;4(b.t||A){B{4(b.t){v+=3.l;u+=3.n}4(A&&3!=9&&$.r(3,\'1w\')!=\'J\'){x+=f(3,\'j\');y+=f(3,\'k\')}3=3.S}H(3!=6)}3=6;4(3.s==\'G\'||3.s==\'1e\'){4((1p||(E&&$.I))&&L!=\'1g\'&&L!=\'1f\'){x+=f(3,\'V\');y+=f(3,\'T\')}4((A&&!12&&L!=\'1f\')||(E&&L==\'W\'&&!14)){x+=f(3,\'j\');y+=f(3,\'k\')}1v}}H(3)}p a=e(9,b,x,y,v,u);4(c){$.z(c,a);5 1}o{5 a}},1i:8(b,c){p x=0,y=0,v=0,u=0,3=1[0],6,b=$.z({Q:F,K:m,O:m,t:F},b||{});B{x+=3.N;y+=3.M;6=3.R;4(b.t){B{v+=3.l;u+=3.n;3=3.S}H(3!=6)}3=6}H(3&&3.s!=\'G\'&&3.s!=\'1e\');p a=e(1[0],b,x,y,v,u);4(c){$.z(c,a);5 1}o{5 a}}});p f=8(b,a){5 1D($.r(b.1C?b[0]:b,a))||0};p e=8(b,c,x,y,a,d){4(!c.Q){x-=f(b,\'V\');y-=f(b,\'T\')}4(c.K&&($.i.Y||$.i.X)){x+=f(b,\'j\');y+=f(b,\'k\')}o 4(!c.K&&!($.i.Y||$.i.X)){x-=f(b,\'j\');y-=f(b,\'k\')}4(c.O){x+=f(b,\'15\');y+=f(b,\'18\')}4(c.t){a-=b.l;d-=b.n}5 c.t?{1b:y-d,1r:x-a,n:d,l:a}:{1b:y,1r:x}}})(1l);',62,109,'|this||parent|if|return|op|document|function|elem||||||||window|browser|borderLeftWidth|borderTopWidth|scrollLeft|false|scrollTop|else|var|body|css|tagName|scroll|st|sl|width|||extend|mo|do|position|height|ie|true|BODY|while|boxModel|visible|border|elemPos|offsetTop|offsetLeft|padding|is|margin|offsetParent|parentNode|marginTop|parPos|marginLeft|static|opera|safari|self|documentElement|offsetWidth|absparent|offsetHeight|relparent|paddingLeft|msie|mozilla|paddingTop|fn|innerHeight|top|clientWidth|innerWidth|HTML|fixed|absolute|arguments|offsetLite|lite|apply|jQuery|scrollTo|oa|each|sf|undefined|left|max|Math|paddingRight|break|overflow|borderRightWidth|paddingBottom|clientHeight|borderBottomWidth|scrollWidth|jquery|parseInt|relative|pageYOffset|pageXOffset|scrollHeight|offset|outerWidth|outerHeight'.split('|'),0,{}))
+
+(function($){
+	
+$.dimensions = {
+	version: '@VERSION'
+};
+
+// Create innerHeight, innerWidth, outerHeight and outerWidth methods
+$.each( [ 'Height', 'Width' ], function(i, name){
+	
+	// innerHeight and innerWidth
+	$.fn[ 'inner' + name ] = function() {
+		if (!this[0]) return;
+		
+		var torl = name == 'Height' ? 'Top'    : 'Left',  // top or left
+		    borr = name == 'Height' ? 'Bottom' : 'Right'; // bottom or right
+		
+		return num( this, name.toLowerCase() ) + num(this, 'padding' + torl) + num(this, 'padding' + borr);
+	};
+	
+	// outerHeight and outerWidth
+	$.fn[ 'outer' + name ] = function(options) {
+		if (!this[0]) return;
+		
+		var torl = name == 'Height' ? 'Top'    : 'Left',  // top or left
+		    borr = name == 'Height' ? 'Bottom' : 'Right'; // bottom or right
+		
+		options = $.extend({ margin: false }, options || {});
+		
+		return num( this, name.toLowerCase() )
+				+ num(this, 'border' + torl + 'Width') + num(this, 'border' + borr + 'Width')
+				+ num(this, 'padding' + torl) + num(this, 'padding' + borr)
+				+ (options.margin ? (num(this, 'margin' + torl) + num(this, 'margin' + borr)) : 0);
+	};
+});
+
+// Create scrollLeft and scrollTop methods
+$.each( ['Left', 'Top'], function(i, name) {
+	$.fn[ 'scroll' + name ] = function(val) {
+		if (!this[0]) return;
+		
+		return val != undefined ?
+		
+			// Set the scroll offset
+			this.each(function() {
+				this == window || this == document ?
+					window.scrollTo( 
+						name == 'Left' ? val : $(window)[ 'scrollLeft' ](),
+						name == 'Top'  ? val : $(window)[ 'scrollTop'  ]()
+					) :
+					this[ 'scroll' + name ] = val;
+			}) :
+			
+			// Return the scroll offset
+			this[0] == window || this[0] == document ?
+				self[ (name == 'Left' ? 'pageXOffset' : 'pageYOffset') ] ||
+					$.boxModel && document.documentElement[ 'scroll' + name ] ||
+					document.body[ 'scroll' + name ] :
+				this[0][ 'scroll' + name ];
+	};
+});
+
+$.fn.extend({
+	position: function() {
+		var left = 0, top = 0, elem = this[0], offset, parentOffset, offsetParent, results;
+		
+		if (elem) {
+			// Get *real* offsetParent
+			offsetParent = this.offsetParent();
+			
+			// Get correct offsets
+			offset       = this.offset();
+			parentOffset = offsetParent.offset();
+			
+			// Subtract element margins
+			offset.top  -= num(elem, 'marginTop');
+			offset.left -= num(elem, 'marginLeft');
+			
+			// Add offsetParent borders
+			parentOffset.top  += num(offsetParent, 'borderTopWidth');
+			parentOffset.left += num(offsetParent, 'borderLeftWidth');
+			
+			// Subtract the two offsets
+			results = {
+				top:  offset.top  - parentOffset.top,
+				left: offset.left - parentOffset.left
+			};
+		}
+		
+		return results;
+	},
+	
+	offsetParent: function() {
+		var offsetParent = this[0].offsetParent;
+		while ( offsetParent && (!/^body|html$/i.test(offsetParent.tagName) && $.css(offsetParent, 'position') == 'static') )
+			offsetParent = offsetParent.offsetParent;
+		return $(offsetParent);
+	}
+});
+
+function num(el, prop) {
+	return parseInt($.css(el.jquery?el[0]:el,prop))||0;
+}
+
+})(jQuery);


### PR DESCRIPTION
There were some issues with using timegrid in conjunction with newer versions of jQuery that removed $.browser functionality (versions since 1.9). These fixes replace the jquery.corner.js and jquery.dimensions.js scripts, as well as replace the $.browser calls with pure JavaScript checks of the browser so timegrid works with the updated versions of jQuery.
